### PR TITLE
Modify ignore to not include config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ docs/
 .idea/*
 .DS_Store
 *.log
+
+config.json


### PR DESCRIPTION
`config.json` contains sensitive values such as the token of the bot, so this will need to be ignored to prevent future commits from accidentally pushing tokens.